### PR TITLE
Change wrapper css class for more private function 

### DIFF
--- a/DropdownContent.php
+++ b/DropdownContent.php
@@ -92,7 +92,7 @@ class DropdownContent extends InputWidget
      */
     public function renderWidget()
     {
-        $result = '<div class="wrapper">';
+        $result = '<div class="dropdown-wrapper">';
         $options = [
             'autocomplete' => 'off'
         ];

--- a/assets/DropdownContent.css
+++ b/assets/DropdownContent.css
@@ -65,10 +65,10 @@
   text-decoration: none;
   background-color: #F5F5F5;
 }
-.dropdown-content .wrapper {
+.dropdown-content .dropdown-wrapper {
   position: relative;
 }
-.dropdown-content .wrapper input {
+.dropdown-content .dropdown-wrapper input {
   padding-right: 37px;
 }
 .dropdown-content .controll-wrapper {
@@ -105,7 +105,7 @@
   border-top: none;
   border-bottom: 4px dashed;
 }
-.dropdown-content.active .wrapper input {
+.dropdown-content.active .dropdown-wrapper input {
   border-bottom-right-radius: 0px;
   border-bottom-left-radius: 0px;
   border-bottom: medium none white;

--- a/assets/DropdownContent.js
+++ b/assets/DropdownContent.js
@@ -21,7 +21,7 @@ $.widget("execut.dropdownContent", {
     _initElements: function () {
         var t = this,
             el = t.element;
-        t.wrapperEl = el.find('.wrapper');
+        t.wrapperEl = el.find('.dropdown-wrapper');
         t.hiddenInput = t.wrapperEl.find('input[type=hidden]');
         t.inputEl = t.wrapperEl.find('input[type=text]');
         t.containerEl = el.find('.dropdown-content-container');

--- a/assets/DropdownContent.less
+++ b/assets/DropdownContent.less
@@ -76,7 +76,7 @@
     }
   }
 
-  .wrapper {
+  .dropdown-wrapper {
     position: relative;
     //z-index: 10000;
     input {
@@ -125,7 +125,7 @@
       }
     }
 
-    .wrapper input {
+    .dropdown-wrapper input {
       border-bottom-right-radius: 0px;
       border-bottom-left-radius: 0px;
       border-bottom: medium none white;


### PR DESCRIPTION
I think write css class `wrapper` for this plugin sometimes will conflict with anthoer css class (even when using Nested CSS with `.dropdown-content`), in many themes/layout/framework `wrapper` class ussualy use in their template.
